### PR TITLE
Expose Hermes dashboard over Tailscale

### DIFF
--- a/cluster/hermes/ingress-tailscale.yaml
+++ b/cluster/hermes/ingress-tailscale.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: hermes-tailscale
+  namespace: hermes
+  labels:
+    app: hermes
+  annotations:
+    tailscale.com/hostname: hermes
+spec:
+  ingressClassName: tailscale
+  rules:
+    - host: hermes
+      http:
+        paths:
+          - pathType: Prefix
+            path: "/"
+            backend:
+              service:
+                name: dashboard
+                port:
+                  number: 9119
+  tls:
+    - hosts:
+        - hermes


### PR DESCRIPTION
## Summary
- Add a second `Ingress` in `cluster/hermes/` that uses the `tailscale` `IngressClass` to expose the existing `dashboard` Service (port 9119) over the tailnet, alongside the current HAProxy-fronted public ingress at `hermes.herron.dev`.
- Sets `tailscale.com/hostname: hermes` so the service is reachable at `https://hermes.<tailnet>.ts.net` (TLS handled by Tailscale's built-in HTTPS, no cert-manager/HAProxy annotations needed).
- No changes to the existing HAProxy `Ingress`, `Service`, or `StatefulSet` — this is purely an additional exposure path using the `tailscale-operator` already deployed in `cluster/tailscale/`.

## Test plan
- [ ] `kubectl apply -f cluster/hermes/ingress-tailscale.yaml` (or let Flux reconcile) and confirm the `tailscale` operator provisions a proxy Pod/Service for the `hermes-tailscale` Ingress
- [ ] Confirm `https://hermes.<tailnet>.ts.net` (per the configured tailnet's MagicDNS) resolves and serves the Hermes dashboard from a tailnet-joined device
- [ ] Confirm the existing `https://hermes.herron.dev` HAProxy ingress path is unaffected


---
_Generated by [Claude Code](https://claude.ai/code/session_01C6VCtPBYXr521ZUYyMyCpz)_